### PR TITLE
add code so tests run in newer versions of django

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: python
 python:
-  - "2.6"
   - "2.7"
 install:
   - pip install -q -e . --use-mirrors

--- a/runtests.py
+++ b/runtests.py
@@ -8,6 +8,14 @@ if not settings.configured:
     settings_dict = dict(
         INSTALLED_APPS=("djsixpack",),
         DATABASES={"default": {"ENGINE": "django.db.backends.sqlite3", "NAME": ":memory:"}},
+        MIDDLEWARE_CLASSES = (
+             'django.contrib.sessions.middleware.SessionMiddleware',
+             'django.middleware.common.CommonMiddleware',
+             'django.middleware.csrf.CsrfViewMiddleware',
+             'django.contrib.auth.middleware.AuthenticationMiddleware',
+             'django.contrib.messages.middleware.MessageMiddleware',
+             'django.middleware.clickjacking.XFrameOptionsMiddleware',
+        )
     )
 
     settings.configure(**settings_dict)
@@ -20,8 +28,17 @@ def runtests(*test_args):
     parent = os.path.dirname(os.path.abspath(__file__))
     sys.path.insert(0, parent)
 
-    from django.test.simple import DjangoTestSuiteRunner
-    failures = DjangoTestSuiteRunner(verbosity=1, interactive=True, failfast=False).run_tests(test_args)
+    try:
+        from django import setup
+        setup()
+    except ImportError:
+        pass
+
+    from django.test.runner import DiscoverRunner
+    from django.test.utils import setup_test_environment
+    setup_test_environment()
+
+    failures = DiscoverRunner(pattern="*tests.py", verbosity=1, interactive=True, failfast=False).run_tests(test_args)
     sys.exit(failures)
 
 if __name__ == '__main__':

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ setup(
         'Development Status :: 5 - Production/Stable',
         'Framework :: Django',
         'Natural Language :: English',
-        'Programming Language :: Python',
+        'Programming Language :: Python :: 2.7',
         'License :: OSI Approved :: BSD License',
         'Operating System :: OS Independent',
     ),


### PR DESCRIPTION
DiscoverRunner was added in 1.6 and tests will not run in newer versions of Django due to changes in the application loading. A fix that will make the test runner run/pass.
