### PR TITLE
Upgraded to 1.1.2 to fix duplicate entries

### DIFF
--- a/djsixpack/__init__.py
+++ b/djsixpack/__init__.py
@@ -1,1 +1,1 @@
-__version__ = "1.1.2"
+__version__ = "1.1.2-wave"

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from setuptools import setup, find_packages
 
-install_reqs = ["Django>=1.4", "sixpack-client==1.1.2", "South>=1.0.0"]
+install_reqs = ["Django>=1.4", "sixpack-client-wave==1.1.2-wave", "South>=1.0.0"]
 
 setup(
     name='django-sixpack',


### PR DESCRIPTION
# DO NOT MERGE THIS BRANCH

Update to work with [**sixpack-wave==2.1.0-wave**](waveaccounting/sixpack#1) and [**Sixpack-client-wave==1.1.2-wave**](https://github.com/waveaccounting/sixpack-py/pull/3)
