### PR TITLE
[JIRA](DLF-344) Fix participate() so it doesn't create duplicates in different buckets 

### DIFF
--- a/djsixpack/__init__.py
+++ b/djsixpack/__init__.py
@@ -1,1 +1,1 @@
-__version__ = "1.1.4-wave"
+__version__ = "1.1.5-wave"

--- a/djsixpack/djsixpack.py
+++ b/djsixpack/djsixpack.py
@@ -127,7 +127,6 @@ class SixpackTest(object):
         if not self.host:
             return True
 
-        import ipdb; ipdb.set_trace()
         session = self._get_session()
         experiment_name = self._get_experiment_name()
         try:

--- a/djsixpack/djsixpack.py
+++ b/djsixpack/djsixpack.py
@@ -111,13 +111,15 @@ class SixpackTest(object):
             chosen_alternative = resp['alternative']['name']
         finally:
             if self.local and chosen_alternative:
-                try:
+
+                # Record the bucket in the database if one doesn't already exist.
+                if not SixpackParticipant.objects.filter(unique_attr=self.client_id, experiment_name=experiment_name).exists():
                     SixpackParticipant.objects.get_or_create(unique_attr=self.client_id, experiment_name=experiment_name, bucket=chosen_alternative)
-                except SixpackParticipant.MultipleObjectsReturned:
-                    # clean up duplicate entries
-                    duplicates = SixpackParticipant.objects.filter(unique_attr=self.client_id, experiment_name=experiment_name, bucket=chosen_alternative)
-                    for dup in duplicates[1:]:
-                        dup.delete()
+
+                # Check for duplicate records and delete them.
+                duplicates = SixpackParticipant.objects.filter(unique_attr=self.client_id, experiment_name=experiment_name).order_by('id')
+                for dup in duplicates[1:]:
+                    dup.delete()
 
         return chosen_alternative
 

--- a/djsixpack/djsixpack.py
+++ b/djsixpack/djsixpack.py
@@ -127,6 +127,7 @@ class SixpackTest(object):
         if not self.host:
             return True
 
+        import ipdb; ipdb.set_trace()
         session = self._get_session()
         experiment_name = self._get_experiment_name()
         try:

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ setup(
     description='A django-friendly wrapper for sixpack-py',
     long_description=open('README.rst').read(),
     install_requires=install_reqs,
-    tests_require=install_reqs + ["mock==1.0.1"],
+    tests_require=install_reqs + ["mock==1.0.1", "factory-boy==1.1.3"],
     test_suite='runtests.runtests',
     classifiers=(
         'Development Status :: 5 - Production/Stable',


### PR DESCRIPTION
The previous code did a `get_or_create()` for the `unique_attr`, `experiment_name` and `bucket` fields.  So if `get_or_create()` was called a second time with the same `unique_attr` and `experiment_name`, but a different `bucket` value then it would create a new record.
